### PR TITLE
[GEN-532] Fixed a fatal error in pipeline finalization

### DIFF
--- a/kflow/include/kflow/Stage.h
+++ b/kflow/include/kflow/Stage.h
@@ -30,6 +30,7 @@ class StageBase {
   float accx_priority_ = 1.0;
 
   int getMaxNumThreads();
+  int incFinalizedThreads();
 
   virtual void start();
   virtual void stop();
@@ -105,7 +106,8 @@ class StageBase {
   mutable boost::atomic<int>  num_finalized_upstream_stages_;
   mutable boost::atomic<bool> is_final_;
   boost::thread_group         worker_threads_;
-
+  
+  boost::mutex mtx_;
 };
 
 template <

--- a/kflow/src/MegaPipe.cpp
+++ b/kflow/src/MegaPipe.cpp
@@ -144,10 +144,10 @@ void MegaPipe::dworker_func(int pipeline_id)
         if (sid == 0) {
           if (stage->isFinal()) {
             if (stage->getNumThreads()==0 && stage->inputQueueEmpty()) {
-              stage->finalize();
-            }
-            if (stage->inputQueueEmpty())
+              if (stage->incFinalizedThreads() == pipeline->num_threads_)
+                stage->finalize();
               pipeline_structure.pop_front();
+            }
           }
           else {
             sid++;

--- a/kflow/src/Stage.cpp
+++ b/kflow/src/Stage.cpp
@@ -93,8 +93,7 @@ void StageBase::finalize() {
   }
   else {
     // otherwise this will be called by compute()
-    num_finalized_workers_.fetch_add(1);
-    if (num_finalized_workers_.load() == num_workers_) {
+    if (incFinalizedThreads() == num_workers_) {
       for (int i = 0; i < downstream_stages_.size(); i++) {
         downstream_stages_[i]->final();
       }
@@ -121,6 +120,13 @@ int StageBase::getNumThreads() {
   else {
     return num_workers_;
   }
+}
+
+int StageBase::incFinalizedThreads() {
+  boost::lock_guard<boost::mutex> guard(mtx_);
+  num_finalized_workers_.fetch_add(1); 
+  int val = num_finalized_workers_.load();
+  return val;
 }
 
 int StageBase::getMaxNumThreads() {


### PR DESCRIPTION
Issue: Bwa-flow failed when there is only one batch to process. See https://falcon-computing.atlassian.net/browse/GEN-532
Fix: Each working thead increases `num_finalized_threads_` sequentially. Only the last thread sends out the finalization signal.