### PR TITLE
GEN-637: bwa-flow segmentation fault at UCLA-TCGB

### DIFF
--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -21,10 +21,15 @@
 #define COMPUTE_DEPTH 64
 
 // Common data structures
+struct kseq_buf_t {
+  kseq_new_t* ks;
+  int size;
+};
+
 struct KseqsRecord {
   uint64_t start_idx;
   int batch_num;
-  kseq_new_t* ks_buffer;
+  kseq_buf_t ks_buffer;
   const char* name = "KseqsRecord";
 };
 


### PR DESCRIPTION
In `getKseqBatch`, the `ks_buffer[t]` access may overflow since the `ks_buffer` is allocated to a fixed length. Now we add a `realloc()` clause to avoid the problem.