### PR TITLE
Fix(GEN-792): bwa-flow segmentation fault on AWS with SDX 17.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ add_subdirectory(bwa bwa_c)
 
 # set up for compilation
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -fPIC -DUSE_HTSLIB")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -rdynamic -Og")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -rdynamic -Wall -DUSELICENSE")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -DUSELICENSE")
 if ( USE_MPI )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_LINK_FLAGS}")
 endif()
@@ -143,14 +143,14 @@ set (CMAKE_STATIC_LINKER_FLAGS "--as-needed")
 target_link_libraries(bwa-flow
   bwa-c
   kflow 
-  ${FPGA_LIBRARIES}
   ${FalconLM_LIBRARIES}
   ${HTS_LIBRARIES}
   ${Google_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
+  ${Boost_LIBRARIES}
   ${ZLIB_LIBRARIES}
   ${CMAKE_DL_LIBS}
-  ${Boost_LIBRARIES})
+  ${FPGA_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT})
 
 if ( USE_MPI )
   add_executable(bwa-mpi ${CMAKE_CURRENT_SOURCE_DIR}/src/mpi_main.cpp ${BWA_MPI_SRC_LIST} ${BWA_SRC_LIST})


### PR DESCRIPTION
When running on AWS or any environment with SDx 17.4, bwa-flow will have a segmentation fault with the following stack trace:
```
./bwa-flow(_Z12trace_dumperi+0x1b)[0x48b16b]
/usr/lib64/libc.so.6(+0x362f0)[0x7f672e15c2f0]
/curr/software/Xilinx/SDx/2017.4/lib/lnx64.o/libxilinxopencl.so(_ZN5boost10filesystem6detail6statusERKNS0_4pathEPNS_6system10error_codeE+0x1d)[0x7f673068fd2d]
./bwa-flow(_ZN5boost10filesystem6existsERKNS0_4pathE+0xe)[0x48e010]
./bwa-flow(main+0x417)[0x48b93b]
/usr/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f672e148445]
./bwa-flow[0x44a95a]
```

The error itself does not make any sense, and it seems to be originated inside OpenCL lib. Using GDB and it shows the segfault is caused by the following line: https://github.com/falcon-computing/bwa-flow/blob/016fdec3335f8db4e05868b944ce948d501bcacc/src/main.cpp#L136

From the trace it looks like the `boost::filesystem::exists()` call triggers a stack in *libxilinxopencl.so* who also has a copy of `boost::filesystem`. This results in a conflict. The fix is link *libxilinxopencl.so* after boost libraries, so that the correct library is picked. 